### PR TITLE
fix(flake.nix): remove hostname specification

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,13 +54,14 @@
 
       # Stand alone home-manager
       homeConfigurations = {
-        "ryanpatterson-cross@MacBookPro.powerhub" =
+        # different user name on mac
+        "ryanpatterson-cross" =
           let
             pkgs = nixpkgs.legacyPackages."aarch64-darwin";
           in
           home-manager.lib.homeManagerConfiguration {
             inherit pkgs;
-            modules = [ ./home/ryanpatterson-cross/home.nix ];
+            modules = [ ./home/ryanpatterson-cross.nix ];
             extraSpecialArgs = {
               editor = minixvim.packages."aarch64-darwin".default;
             };


### PR DESCRIPTION
Removes hostname from stand-alone host-manager configurations, and corrects import from home.
